### PR TITLE
fix: Add ScoutFS protocol support to location creation wizard

### DIFF
--- a/src/tellus/location/cli.py
+++ b/src/tellus/location/cli.py
@@ -111,6 +111,7 @@ def create(name, protocol, kind, is_optional, **storage_options):
         protocol_choices = [
             {"name": "file - Local filesystem", "value": "file"},
             {"name": "sftp - SSH File Transfer Protocol", "value": "sftp"},
+            {"name": "scoutfs - ScoutFS with tape staging", "value": "scoutfs"},
             {"name": "s3 - Amazon S3", "value": "s3"},
             {"name": "gs - Google Cloud Storage", "value": "gs"},
             {"name": "azure - Azure Blob Storage", "value": "azure"},
@@ -167,13 +168,13 @@ def create(name, protocol, kind, is_optional, **storage_options):
             if path:
                 storage_opts["path"] = path
 
-        elif protocol in ["sftp", "ftp"]:
+        elif protocol in ["sftp", "scoutfs", "ftp"]:
             host = questionary.text("Enter hostname:").ask()
             if host:
                 storage_opts["host"] = host
             
             port_str = questionary.text(
-                f"Enter port (default: {22 if protocol == 'sftp' else 21}):",
+                f"Enter port (default: {22 if protocol in ['sftp', 'scoutfs'] else 21}):",
                 default=""
             ).ask()
             if port_str:


### PR DESCRIPTION
Added ScoutFS to the location creation wizard protocol choices.

This resolves the issue where ScoutFS was implemented in the codebase but not available as an option in the CLI wizard.

Changes:
- Added ScoutFS to protocol choices with description
- Configured ScoutFS to use SSH-like settings (port 22, host, username, password, path)

Closes #9

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Enable ScoutFS protocol support in the CLI location creation wizard by adding it to the protocol choices and configuring SSH-like settings

Bug Fixes:
- Include ScoutFS in protocol selection list
- Handle ScoutFS like SFTP for hostname and port prompts with default port 22